### PR TITLE
still no pnl and order history due to that, this needs to be adjusted…

### DIFF
--- a/hummingbot/connector/exchange/bitmart/bitmart_constants.py
+++ b/hummingbot/connector/exchange/bitmart/bitmart_constants.py
@@ -23,11 +23,11 @@ CHECK_NETWORK_PATH_URL = "system/service"
 GET_TRADING_RULES_PATH_URL = "spot/v1/symbols/details"
 GET_LAST_TRADING_PRICES_PATH_URL = "spot/v1/ticker"
 GET_ORDER_BOOK_PATH_URL = "spot/v1/symbols/book"
-CREATE_ORDER_PATH_URL = "spot/v1/submit_order"
-CANCEL_ORDER_PATH_URL = "spot/v2/cancel_order"
+CREATE_ORDER_PATH_URL = "spot/v2/submit_order"
+CANCEL_ORDER_PATH_URL = "spot/v3/cancel_order"
 GET_ACCOUNT_SUMMARY_PATH_URL = "spot/v1/wallet"
-GET_ORDER_DETAIL_PATH_URL = "spot/v2/order_detail"
-GET_TRADE_DETAIL_PATH_URL = "spot/v1/trades"
+GET_ORDER_DETAIL_PATH_URL = "spot/v4/query/order"
+GET_TRADE_DETAIL_PATH_URL = "spot/v4/query/trades"
 SERVER_TIME_PATH = "system/time"
 
 # WS API ENDPOINTS
@@ -51,12 +51,19 @@ RATE_LIMITS = [
 ]
 
 ORDER_STATE = {
-    "1": OrderState.FAILED,
-    "2": OrderState.OPEN,
-    "3": OrderState.FAILED,
+    "new": OrderState.OPEN,
+    "partially_filled": OrderState.PARTIALLY_FILLED,
+    "filled": OrderState.FILLED,
+    "canceled": OrderState.CANCELED,
+    "partially_canceled": OrderState.CANCELED,
     "4": OrderState.OPEN,
     "5": OrderState.PARTIALLY_FILLED,
     "6": OrderState.FILLED,
-    "7": OrderState.PENDING_CANCEL,
     "8": OrderState.CANCELED,
+    "12": OrderState.CANCELED,
+    4: OrderState.OPEN,
+    5: OrderState.PARTIALLY_FILLED,
+    6: OrderState.FILLED,
+    8: OrderState.CANCELED,
+    12: OrderState.CANCELED,
 }


### PR DESCRIPTION
… so inflight order and client order tracker can be reverted to normal without extra handlers

As commit says, TODO, fix pnl logging, revert client_order_tracker and in_flight_order back to normal, for now they have additional handling of those duplicate orders that seem to appear and mess up available balance due to filled amount stacking.  


